### PR TITLE
Optimized ip checking algorithm for ipv6

### DIFF
--- a/internal/tools/iptools_test.go
+++ b/internal/tools/iptools_test.go
@@ -42,6 +42,7 @@ func TestValidIP6(t *testing.T) {
 		"::4:5:6:7:8",
 		"::3:4:5:6:7:8",
 		"::2:3:4:5:6:7:8",
+		"2001:0db8:85a3:0000:0000:8a2e:0370:7334",
 
 		"::192.168.1.1",
 		"::ffff:135.75.43.52",
@@ -52,6 +53,8 @@ func TestValidIP6(t *testing.T) {
 		"A:0f:0F:FFFF1:5:6:7:8",
 		"G:0f:0F:FFFF:5:6:7:8",
 		"2001::25de::cade",
+		"2001:0db8:85a3:0:0:8A2E:0370:73341",
+		"a1:a2:a3:a4::b1:b2:b3:b4",
 	}
 
 	for _, i := range ipv6Valid {
@@ -66,3 +69,43 @@ func TestValidIP6(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkValidIP6Re(b *testing.B) {
+	b.ResetTimer()
+	origin := "::ffff:135.75.43.52"
+	for i:=0; i<b.N;i++ {
+		ValidIP6Re(origin)
+	}
+}
+
+func BenchmarkValidIP6(b *testing.B) {
+	b.ResetTimer()
+	origin := "::ffff:135.75.43.52"
+	for i:=0; i<b.N;i++ {
+		ValidIP6(origin)
+	}
+}
+
+/*
+
+   IPv6-addr      = IPv6-full / IPv6-comp / IPv6v4-full / IPv6v4-comp
+
+   IPv6-hex       = 1*4HEXDIG
+
+   IPv6-full      = IPv6-hex 7(":" IPv6-hex)
+
+   IPv6-comp      = [IPv6-hex *5(":" IPv6-hex)] "::"
+                  [IPv6-hex *5(":" IPv6-hex)]
+                  ; The "::" represents at least 2 16-bit groups of
+                  ; zeros.  No more than 6 groups in addition to the
+                  ; "::" may be present.
+
+   IPv6v4-full    = IPv6-hex 5(":" IPv6-hex) ":" IPv4-address-literal
+
+   IPv6v4-comp    = [IPv6-hex *3(":" IPv6-hex)] "::"
+                  [IPv6-hex *3(":" IPv6-hex) ":"]
+                  IPv4-address-literal
+                  ; The "::" represents at least 2 16-bit groups of
+                  ; zeros.  No more than 4 groups in addition to the
+                  ; "::" and IPv4-address-literal may be present.
+*/


### PR DESCRIPTION
Benchmark, 使用正则的速度是比较慢的. #14 

```
$ go test -v -bench=. -benchtime=3s -benchmem                                
=== RUN   TestIP4Re
[1.1.11.23 36.36.32.200]
false
--- PASS: TestIP4Re (0.00s)
=== RUN   TestValidIP6
--- PASS: TestValidIP6 (0.00s)
goos: linux
goarch: amd64
pkg: github.com/zu1k/nali/internal/tools
BenchmarkValidIP6Re
BenchmarkValidIP6Re-8             807940              4429 ns/op              32 B/op          1 allocs/op
BenchmarkValidIP6
BenchmarkValidIP6-8              9549422               362 ns/op             160 B/op          3 allocs/op
PASS
ok      github.com/zu1k/nali/internal/tools     7.476s

```