### PR TITLE
更新 ZX IPV6 数据库的下载地址

### DIFF
--- a/pkg/zxipv6wry/update.go
+++ b/pkg/zxipv6wry/update.go
@@ -16,7 +16,7 @@ func Download(filePath string) (data []byte, err error) {
 	data, err = getData()
 	if err != nil {
 		log.Printf("ZX IPv6数据库下载失败，请手动下载解压后保存到本地: %s \n", filePath)
-		log.Println("下载链接： https://www.zxinc.org/ip.7z")
+		log.Println("下载链接： https://ip.zxinc.org/ip.7z")
 		return
 	}
 	common.ExistThenRemove(filePath)
@@ -28,7 +28,7 @@ func Download(filePath string) (data []byte, err error) {
 }
 
 func getData() (data []byte, err error) {
-	resp, err := http.Get("https://www.zxinc.org/ip.7z")
+	resp, err := http.Get("https://ip.zxinc.org/ip.7z")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
在 zxinc.org 网站上有两个下载数据库的地址：
- https://www.zxinc.org/ip.7z
- https://ip.zxinc.org/ip.7z
前者直接在首页上有链接，后者从首页里点进 “IP地址查询主站” 可以看到链接。
目前前者下载的数据库是 20200302 版，后者则是 20200506 版，后者比前者新。