### PR TITLE
fix color print in cmd.exe

### DIFF
--- a/internal/app/command.go
+++ b/internal/app/command.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/fatih/color"
 	"github.com/zu1k/nali/internal/entity"
 	"golang.org/x/text/encoding/simplifiedchinese"
 	"golang.org/x/text/transform"
@@ -22,9 +23,9 @@ func Root(args []string, needTransform bool) {
 			if line == "quit" || line == "exit" {
 				return
 			}
-			fmt.Printf("%s\n", entity.ParseLine(line).ColorString())
+			fmt.Fprintf(color.Output, "%s\n", entity.ParseLine(line).ColorString())
 		}
 	} else {
-		fmt.Printf("%s\n", entity.ParseLine(strings.Join(args, " ")).ColorString())
+		fmt.Fprintf(color.Output, "%s\n", entity.ParseLine(strings.Join(args, " ")).ColorString())
 	}
 }


### PR DESCRIPTION
cmd 里的彩色输出有点问题，照着 https://github.com/fatih/color/issues/91 改了下。

截图如下：

![Screenshot](https://user-images.githubusercontent.com/34161108/152946258-0e1a4f29-6bf5-4ddc-8628-a288c0d1d88e.jpg)

