### PR TITLE
fix concurrent map write

### DIFF
--- a/internal/db/cache.go
+++ b/internal/db/cache.go
@@ -1,11 +1,15 @@
 package db
 
-import "github.com/zu1k/nali/pkg/dbif"
+import (
+	"sync"
+
+	"github.com/zu1k/nali/pkg/dbif"
+)
 
 var (
 	dbNameCache = make(map[string]dbif.DB)
 	dbTypeCache = make(map[dbif.QueryType]dbif.DB)
-	queryCache  = make(map[string]string)
+	queryCache  = sync.Map{}
 )
 
 var (

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -70,14 +70,14 @@ func GetDB(typ dbif.QueryType) (db dbif.DB) {
 }
 
 func Find(typ dbif.QueryType, query string) string {
-	if result, found := queryCache[query]; found {
-		return result
+	if result, found := queryCache.Load(query); found {
+		return result.(string)
 	}
 	result, err := GetDB(typ).Find(query)
 	if err != nil {
 		return ""
 	}
 	r := strings.Trim(result.String(), " ")
-	queryCache[query] = r
+	queryCache.Store(query, r)
 	return r
 }


### PR DESCRIPTION
写了个webAPI发现并发大的时候会遇到  concurrent map writes。 可以用 sync.Map 或者sync.Mutex + map处理。 PR采用了前者，目前运行良好。
```log
fatal error: concurrent map writes
goroutine 18613 [running]:
runtime.throw({0x77d5d8?, 0x5?})
        /tmp/go/src/runtime/panic.go:992 +0x71 fp=0xc0002b37d8 sp=0xc0002b37a8 pc=0x433411
runtime.mapassign_faststr(0xc0002dd4d0?, 0xc0002dc919?, {0xc0002dc919, 0xd})
        /tmp/go/src/runtime/map_faststr.go:212 +0x39c fp=0xc0002b3840 sp=0xc0002b37d8 pc=0x41297c
github.com/zu1k/nali/internal/db.Find(0x809408?, {0xc0002dc919, 0xd})
        /tmp/go/pkg/mod/github.com/zu1k/nali@v0.5.0/internal/db/db.go:81 +0xc9 fp=0xc0002b3898 sp=0xc0002b3840 pc=0x6e29c9
github.com/zu1k/nali/pkg/entity.ParseLine({0xc0002dc919, 0xd})
        /tmp/go/pkg/mod/github.com/zu1k/nali@v0.5.0/pkg/entity/parse.go:58 +0x39f fp=0xc0002b39f0 sp=0xc0002b3898 pc=0x6e429f
main.parseIp({0x809318, 0xc0004880e0}, 0x0?)
```


```golang
package main

import (
	"flag"
	"net/http"
	"os"

	"github.com/zu1k/nali/pkg/entity"
)

// https://github.com/zu1k/nali
func parseIp(w http.ResponseWriter, req *http.Request) {
	query := req.URL.Query()
	ip := query.Get("ip")
	res := entity.ParseLine(ip)
	w.Write([]byte(res.String()))
}

func main() {
	port := flag.String("p", "8004", "port")
	flag.Parse()
	cd, _ := os.Getwd()
	// fmt.Println(cd)
	// naliHome := path.Join(cd, ".nali")
	os.Setenv("NALI_HOME", cd)
	http.HandleFunc("/goapi/nali/parse", parseIp)
	http.ListenAndServe(":"+*port, nil)
	// entity.ParseLine("1.1.1.1")

}
```