### PR TITLE
新增使用代理下载IP数据库

### DIFF
--- a/pkg/common/httpclient.go
+++ b/pkg/common/httpclient.go
@@ -23,6 +23,7 @@ func init() {
 		IdleConnTimeout:       time.Second * 10,
 		ResponseHeaderTimeout: time.Second * 10,
 		ExpectContinueTimeout: time.Second * 20,
+		Proxy:                 http.ProxyFromEnvironment,
 	}
 }
 


### PR DESCRIPTION
## 因以下原因,下载IP数据库总是失败： 
   1.  `cdn.jsdelivr.net` 已被屏蔽，不能正常访问。
   2.  `raw.githubusercontent.com` 间歇性不能访问

为了解决上述问题，新增此次修改

## 测试例子
```shell

export http_proxy=http://127.0.0.1:1080
export https_proxy=http://127.0.0.1:1080

test -d ~/.nali/ && rm -rf  ~/.nali/

go run main.go update 

```

## 另外一个解决办法就是，使用镜像地址
> 比如：  `cdn.jsdelivr.net` 更换为 `fastly.jsdelivr.net`