### PR TITLE
fix: panic when config dir access denied

### DIFF
--- a/internal/constant/path.go
+++ b/internal/constant/path.go
@@ -37,13 +37,13 @@ func init() {
 
 func prepareDir(dir string) {
 	stat, err := os.Stat(dir)
-	if err != nil && os.IsNotExist(err) {
+	if os.IsNotExist(err) {
 		if err := os.MkdirAll(dir, 0755); err != nil {
 			log.Fatal("can not create config dir:", dir)
 		}
-	} else {
-		if !stat.IsDir() {
-			log.Fatal("path already exists, but not a dir:", dir)
-		}
+	} else if err != nil {
+		log.Fatal(err)
+	} else if !stat.IsDir() {
+		log.Fatal("path already exists, but not a dir:", dir)
 	}
 }


### PR DESCRIPTION
nali will panic when `ConfigDir` is not accessible
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x0 addr=0x18 pc=0x4b8fa2]

goroutine 1 [running]:
github.com/zu1k/nali/internal/constant.prepareDir({0xc000022f40, 0x35})
        github.com/zu1k/nali/internal/constant/path.go:45 +0xe2
github.com/zu1k/nali/internal/constant.init.0()
        github.com/zu1k/nali/internal/constant/path.go:32 +0x1f8
```
L45 `stat` is possible nil, we need to check other errs to make sure `stat` is not nil. 
In my case, the err is `Access is denied.`
https://github.com/zu1k/nali/blob/20a0de63f1eb447bf22fdbdd0609c3b2abc481f5/internal/constant/path.go#L38-L48
