### PR TITLE
chore: use FW27623/qqwry instead of HMBSbige/qqwry

### DIFF
--- a/pkg/qqwry/qqwry.go
+++ b/pkg/qqwry/qqwry.go
@@ -14,9 +14,9 @@ import (
 )
 
 var DownloadUrls = []string{
-	"https://gh-release.zu1k.com/HMBSbige/qqwry/qqwry.dat", // redirect to HMBSbige/qqwry
+	"https://raw.githubusercontent.com/FW27623/qqwry/main/qqwry.dat",
 	// Other repo:
-	// https://github.com/HMBSbige/qqwry
+	// https://github.com/HMBSbige/qqwry // This repository has been archived since Jun 27, 2024.
 	// https://github.com/metowolf/qqwry.dat
 }
 


### PR DESCRIPTION
[HMBSbige/qqwr](https://github.com/HMBSbige/qqwry)y has been archived since Jun 27, 2024. 
use [FW27623/qqwry](https://github.com/FW27623/qqwry) to replace it.