### PR TITLE
feat: add windows-arm64 support in WINDOWS_ARCH_LIST

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,8 @@ PLATFORM_LIST = \
 
 WINDOWS_ARCH_LIST = \
 	windows-386 \
-	windows-amd64
+	windows-amd64 \
+	windows-arm64
 
 all: linux-amd64 darwin-amd64 windows-amd64 # Most used
 
@@ -83,6 +84,9 @@ windows-386:
 
 windows-amd64:
 	GOARCH=amd64 GOOS=windows $(GOBUILD) -o $(BINDIR)/$(NAME)-$@.exe
+
+windows-arm64:
+	GOARCH=arm64 GOOS=windows $(GOBUILD) -o $(BINDIR)/$(NAME)-$@.exe
 
 gz_releases=$(addsuffix .gz, $(PLATFORM_LIST))
 zip_releases=$(addsuffix .zip, $(WINDOWS_ARCH_LIST))


### PR DESCRIPTION
Added support for windows-arm64 architecture in the Makefile as requested in issue #201.