### PR TITLE
Update qqwry data source URL to metowolf/qqwry

### DIFF
--- a/pkg/qqwry/qqwry.go
+++ b/pkg/qqwry/qqwry.go
@@ -14,9 +14,10 @@ import (
 )
 
 var DownloadUrls = []string{
-	"https://raw.githubusercontent.com/FW27623/qqwry/main/qqwry.dat",
+	"https://github.com/metowolf/qqwry.dat/releases/latest/download/qqwry.dat",
 	// Other repo:
 	// https://github.com/HMBSbige/qqwry // This repository has been archived since Jun 27, 2024.
+	// https://github.com/FW27623/qqwry // This repository's dat format will not be maintained after October 2024.
 	// https://github.com/metowolf/qqwry.dat
 }
 


### PR DESCRIPTION
纯真官方在 2024 年 10 月份已停止维护 dat 格式，目前仅有 https://github.com/metowolf/qqwry.dat 以逆向 czdb 形式提供 dat 更新支持。