### PR TITLE
httpClientTimeout = 300s

### DIFF
--- a/pkg/common/httpclient.go
+++ b/pkg/common/httpclient.go
@@ -17,7 +17,7 @@ var httpClient *HttpClient
 
 func init() {
 	httpClient = &HttpClient{http.DefaultClient}
-	httpClient.Timeout = time.Second * 60
+	httpClient.Timeout = time.Second * 300
 	httpClient.Transport = &http.Transport{
 		TLSHandshakeTimeout:   time.Second * 5,
 		IdleConnTimeout:       time.Second * 10,


### PR DESCRIPTION
下载 `qqwry.dat` （较大）网速较慢时，经常遇到
```log
Client.Timeout exceeded while awaiting headers
Client.Timeout or context cancellation while reading body
```
于是，将超时时间调整到 300 秒。这也是运营商 CGNAT 常见的会话超时时间